### PR TITLE
Remove the NSA Blocklist and the state-surveillance bundle

### DIFF
--- a/bundles.json
+++ b/bundles.json
@@ -69,12 +69,6 @@
     ]
   },
   {
-    "id": "state-surveillance",
-    "lists": [
-      "nsa-blocklist"
-    ]
-  },
-  {
     "id": "vpns-proxies",
     "lists": []
   },

--- a/lists.json
+++ b/lists.json
@@ -809,14 +809,6 @@
     "url": "https://raw.githubusercontent.com/marktron/fakenews/master/fakenews"
   },
   {
-    "id": "nsa-blocklist",
-    "name": "NSABlocklist",
-    "website": "https://github.com/CHEF-KOCH/NSABlocklist",
-    "description": "Block all known NSA / GCHQ / C.I.A. / F.B.I. spying servers.",
-    "categories": ["privacy"],
-    "url": "https://raw.githubusercontent.com/CHEF-KOCH/NSABlocklist/master/HOSTS/HOSTS"
-  },
-  {
     "id": "dbloisdnl",
     "name": "dbl.oisd.nl",
     "website": "https://www.reddit.com/r/pihole/comments/9xwwwy/just_sharing_my_blocklist",


### PR DESCRIPTION
I've recently started using NextDNS, and I find it to be totally awesome! 

However, the NSA Blocklist, while very _very_ thorough, has far too many false positives, and is enabled by default. There are 100s of legitimate sites there that are blocked as false positive, and are part of peoples every day life. A few examples:
- [`ca.gov`](https://ca.gov): The website for the government of California. Includes their DMV website, the Secretary of State's website, and many other important resources to residents of the state of California
- [`ny.gov`](https://ny.gov): The same as above, but for the State of New York
- [`bart.gov`](https://bart.gov): The website for Bay Area Rapid Transit(BART), a public transportation agency in the San Francisco Bay Area.
- [`irs.gov`](https://irs.gov): The website for the US Internal Revenue Service(IRS), the United States federal tax collector.

Interestingly, it doesn't even block the entire `nsa.gov` domain, which surprises me based on it's name.

As such, I feel it should be removed. Personally, I've disabled it, but it's enabled by default and I also believe that enabling it by default is poor user experience.